### PR TITLE
Fix some bugs in function parameter/output location

### DIFF
--- a/fixtures/abis/UniswapV3Factory.json
+++ b/fixtures/abis/UniswapV3Factory.json
@@ -1,0 +1,148 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickSpacing",
+        "type": "int24"
+      }
+    ],
+    "name": "FeeAmountEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint24",
+        "name": "fee",
+        "type": "uint24"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tickSpacing",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenA", "type": "address" },
+      { "internalType": "address", "name": "tokenB", "type": "address" },
+      { "internalType": "uint24", "name": "fee", "type": "uint24" }
+    ],
+    "name": "createPool",
+    "outputs": [
+      { "internalType": "address", "name": "pool", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint24", "name": "fee", "type": "uint24" },
+      { "internalType": "int24", "name": "tickSpacing", "type": "int24" }
+    ],
+    "name": "enableFeeAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint24", "name": "", "type": "uint24" }],
+    "name": "feeAmountTickSpacing",
+    "outputs": [{ "internalType": "int24", "name": "", "type": "int24" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint24", "name": "", "type": "uint24" }
+    ],
+    "name": "getPool",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "parameters",
+    "outputs": [
+      { "internalType": "address", "name": "factory", "type": "address" },
+      { "internalType": "address", "name": "token0", "type": "address" },
+      { "internalType": "address", "name": "token1", "type": "address" },
+      { "internalType": "uint24", "name": "fee", "type": "uint24" },
+      { "internalType": "int24", "name": "tickSpacing", "type": "int24" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/lib/interface.go
+++ b/lib/interface.go
@@ -89,7 +89,7 @@ func GenerateType(typeCounter *int, internalType string) string {
 // This function returns true if the given Solidity type requires a location modifier ("memory", "storage", "calldata")
 // when used as a function parameter or return value.
 func SolidityTypeRequiresLocation(solidityType string) bool {
-	if strings.HasSuffix(solidityType, "[]") {
+	if strings.HasSuffix(solidityType, "]") {
 		return true
 	} else if solidityType == "string" {
 		return true
@@ -97,9 +97,11 @@ func SolidityTypeRequiresLocation(solidityType string) bool {
 		return true
 	} else if solidityType == "bool" {
 		return false
+	} else if solidityType == "address" {
+		return false
 	} else if strings.HasPrefix(solidityType, "uint") {
 		return false
-	} else if solidityType == "address" {
+	} else if strings.HasPrefix(solidityType, "int") {
 		return false
 	} else if strings.HasPrefix(solidityType, "bytes") {
 		// It is not exactly "bytes" because that was handled above. "bytes[]" also handled above.

--- a/lib/interface_test.go
+++ b/lib/interface_test.go
@@ -181,3 +181,26 @@ func TestGenerateInterfaceOwnableERC20(t *testing.T) {
 		t.Fatalf("Error generating interface: %s", err.Error())
 	}
 }
+
+func TestGenerateInterfaceUniswapV3Factory(t *testing.T) {
+	contents, readErr := os.ReadFile("../fixtures/abis/UniswapV3Factory.json")
+	if readErr != nil {
+		t.Fatal("Could not read file containing ABI")
+	}
+
+	abi, decodeErr := Decode(contents)
+	if decodeErr != nil {
+		t.Fatalf("Error decoding ABI: %s", decodeErr.Error())
+	}
+
+	var annotations Annotations
+	includeAnnotations := false
+
+	// Replace io.Discard with os.Stdout to inspect output:
+	err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, os.Stdout)
+	// err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, io.Discard)
+
+	if err != nil {
+		t.Fatalf("Error generating interface: %s", err.Error())
+	}
+}

--- a/lib/interface_test.go
+++ b/lib/interface_test.go
@@ -197,8 +197,8 @@ func TestGenerateInterfaceUniswapV3Factory(t *testing.T) {
 	includeAnnotations := false
 
 	// Replace io.Discard with os.Stdout to inspect output:
-	err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, os.Stdout)
-	// err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, io.Discard)
+	// err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, os.Stdout)
+	err := GenerateInterface("IUniswapV3Factory", "UNLICENSED", "^8.20.0", abi, annotations, includeAnnotations, io.Discard)
 
 	if err != nil {
 		t.Fatalf("Error generating interface: %s", err.Error())

--- a/lib/version.go
+++ b/lib/version.go
@@ -1,4 +1,4 @@
 package lib
 
 // The current version of solface.
-var VERSION string = "0.2.2"
+var VERSION string = "0.2.3"


### PR DESCRIPTION
Fixed length arrays were not receiving a location. They are now generated as using `memory`.

Resolves https://github.com/moonstream-to/solface/issues/4